### PR TITLE
Created Setup.py to Pip Install Certifiable Calib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+import setuptools
+
+setuptools.setup(
+    name='certifiable-calib',
+    version='0.1.0',
+    description='Certifiably globally optimal extrinsic calibration for sensors providing egomotion estimates.',
+    author='James Guzman',
+    author_email='jamesmguzman94@gmail.com',
+    license='MIT',
+    # packages=['python', 'python.pose_simulator', 'python.extrinsic_calibration', 'python.extrinsic_calibration.utility', 'python.extrinsic_calibration.solver', 'python.extrinsic_calibration.andreff', 'python.extrinsic_calibration.andreff.liegroups.numpy', 'python.extrinsic_calibration.andreff.liegroups.torch'],
+    packages=setuptools.find_packages(),
+    install_requires=['future', 'numpy', 'liegroups', 'scipy', 'matplotlib', 'cvxpy']
+)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ setuptools.setup(
     author='James Guzman',
     author_email='jamesmguzman94@gmail.com',
     license='MIT',
-    # packages=['python', 'python.pose_simulator', 'python.extrinsic_calibration', 'python.extrinsic_calibration.utility', 'python.extrinsic_calibration.solver', 'python.extrinsic_calibration.andreff', 'python.extrinsic_calibration.andreff.liegroups.numpy', 'python.extrinsic_calibration.andreff.liegroups.torch'],
     packages=setuptools.find_packages(),
     install_requires=['future', 'numpy', 'liegroups', 'scipy', 'matplotlib', 'cvxpy']
 )


### PR DESCRIPTION
**Description**: I added setup.py, so users can pip install certifiable-calibration framework with pip package named "certifiable-calib". I made this update, so it is easier to integrate this framework into existing software infrastructure.

Please let me know if there are other updates I should make in regards to setup.py.